### PR TITLE
Fix title and hard-mode parsing

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,7 +10,7 @@ import type { MetaFunction, LinksFunction } from "remix";
 import styles from './styles.css'
 
 export const meta: MetaFunction = () => {
-  return { title: "New Remix App" };
+  return { title: "Accessible Wordle" };
 };
 
 export const links : LinksFunction = () => {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -3,7 +3,7 @@ import { parseWordleGrid } from "../wordle";
 import * as Sentry from "@sentry/react";
 
 const WORDLE_REGEX =
-  /Wordle (?<version>[0-9]+) (?<attempts>[1-6])\/6(\s+)(?<blocks>[\s\S]*)/;
+  /Wordle (?<version>[0-9]+) (?<attempts>[1-6])\/6\*?(\s+)(?<blocks>[\s\S]*)/;
 
 function parseWordleString(str: string) {
   const match = str.match(WORDLE_REGEX);


### PR DESCRIPTION
Fixes title from "New Remix App" to "Accessible Wordle".

Adds an optional `*` (after guess count) to the Wordle regex to allow parsing Hard Mode output.